### PR TITLE
feat(auth): add google oauth strategy

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from '../users/dto/create-user.dto';
@@ -8,7 +18,10 @@ import { User } from '../users/entities/user.entity';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly configService: ConfigService,
+  ) {}
 
   @Post('register')
   async register(@Body() createUserDto: CreateUserDto) {
@@ -38,5 +51,23 @@ export class AuthController {
   ) {
     const { id, refreshToken } = req.user;
     return this.authService.getNewTokens(id, refreshToken);
+  }
+
+  @Get('google')
+  @UseGuards(AuthGuard('google'))
+  async googleAuth() {}
+
+  @Get('google/callback')
+  @UseGuards(AuthGuard('google'))
+  async googleAuthCallback(
+    @Req() req: Request & { user: User },
+    @Res() res: Response,
+  ) {
+    const tokens = await this.authService.login(req.user);
+    res.cookie('Authentication', tokens.accessToken, { httpOnly: true });
+    res.cookie('Refresh', tokens.refreshToken, { httpOnly: true });
+    return res.redirect(
+      this.configService.get<string>('FRONTEND_URL') ?? '/',
+    );
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,12 +2,12 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
-import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
+import { GoogleStrategy } from './strategies/google.strategy';
 import { AuthController } from './auth.controller';
 
 @Module({
@@ -27,7 +27,13 @@ import { AuthController } from './auth.controller';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, LocalStrategy, JwtStrategy, JwtRefreshStrategy],
+  providers: [
+    AuthService,
+    LocalStrategy,
+    JwtStrategy,
+    JwtRefreshStrategy,
+    GoogleStrategy,
+  ],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/strategies/google.strategy.ts
+++ b/backend/src/auth/strategies/google.strategy.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
+import { Strategy, Profile } from 'passport-google-oauth20';
+import { UsersService } from '../../users/users.service';
+import { User } from '../../users/entities/user.entity';
+
+@Injectable()
+export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly usersService: UsersService,
+  ) {
+    super({
+      clientID: configService.get<string>('GOOGLE_CLIENT_ID') ?? '',
+      clientSecret: configService.get<string>('GOOGLE_CLIENT_SECRET') ?? '',
+      callbackURL: configService.get<string>('GOOGLE_CALLBACK_URL') ?? '',
+      scope: ['email', 'profile'],
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+  ): Promise<User> {
+    const email = profile.emails?.[0]?.value;
+    let user = await this.usersService.findByGoogleId(profile.id);
+    if (!user && email) {
+      user = await this.usersService.findByEmail(email);
+    }
+    if (!user) {
+      const newUser: any = {
+        email: email ?? '',
+        password: profile.id,
+        firstName: profile.name?.givenName,
+        lastName: profile.name?.familyName,
+        profilePictureUrl: profile.photos?.[0]?.value,
+        googleId: profile.id,
+      };
+      user = await this.usersService.create(newUser);
+    }
+    return user;
+  }
+}

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -4,4 +4,5 @@ export class CreateUserDto {
   firstName?: string;
   lastName?: string;
   profilePictureUrl?: string;
+  googleId?: string;
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -24,6 +24,10 @@ export class UsersService {
     return this.usersRepository.findOne({ where: { id } });
   }
 
+  async findByGoogleId(googleId: string): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { googleId } });
+  }
+
   async update(id: string, updateData: Partial<User>): Promise<void> {
     await this.usersRepository.update(id, updateData);
   }


### PR DESCRIPTION
## Summary
- add Google OAuth strategy using passport-google-oauth20
- extend user service to support lookup by Google id
- register Google strategy with auth module
- expose Google login endpoints that set tokens in cookies and redirect to frontend

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977a1bd044832ca0e95650b059e311