### PR TITLE
feat: add task module and entity

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { TasksModule } from './tasks/tasks.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    TasksModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/tasks/dto/create-task.dto.ts
+++ b/backend/src/tasks/dto/create-task.dto.ts
@@ -1,0 +1,7 @@
+import { TaskStatus } from '../entities/task.entity';
+
+export class CreateTaskDto {
+  title: string;
+  description?: string;
+  status?: TaskStatus;
+}

--- a/backend/src/tasks/dto/update-task.dto.ts
+++ b/backend/src/tasks/dto/update-task.dto.ts
@@ -1,0 +1,7 @@
+import { TaskStatus } from '../entities/task.entity';
+
+export class UpdateTaskDto {
+  title?: string;
+  description?: string;
+  status?: TaskStatus;
+}

--- a/backend/src/tasks/entities/task.entity.ts
+++ b/backend/src/tasks/entities/task.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum TaskStatus {
+  TODO = 'TODO',
+  IN_PROGRESS = 'IN_PROGRESS',
+  DONE = 'DONE',
+}
+
+@Entity()
+export class Task {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ type: 'enum', enum: TaskStatus, default: TaskStatus.TODO })
+  status: TaskStatus;
+
+  @ManyToOne(() => User, (user) => user.tasks)
+  user: User;
+}

--- a/backend/src/tasks/tasks.controller.spec.ts
+++ b/backend/src/tasks/tasks.controller.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
+import { Task } from './entities/task.entity';
+
+jest.mock(
+  '@nestjs/passport',
+  () => ({
+    AuthGuard: () => class {},
+  }),
+  { virtual: true },
+);
+
+describe('TasksController', () => {
+  let controller: TasksController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TasksController],
+      providers: [
+        TasksService,
+        {
+          provide: getRepositoryToken(Task),
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TasksController>(TasksController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/tasks/tasks.controller.ts
+++ b/backend/src/tasks/tasks.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+  NotFoundException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TasksService } from './tasks.service';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('tasks')
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Post()
+  create(
+    @Body() createTaskDto: CreateTaskDto,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.tasksService.create(req.user.id, createTaskDto);
+  }
+
+  @Get()
+  findAll(@Req() req: Request & { user: { id: string } }) {
+    return this.tasksService.findAllForUser(req.user.id);
+  }
+
+  @Get(':id')
+  async findOne(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    const task = await this.tasksService.findOneForUser(id, req.user.id);
+    if (!task) {
+      throw new NotFoundException();
+    }
+    return task;
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() updateTaskDto: UpdateTaskDto,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.tasksService.update(id, req.user.id, updateTaskDto);
+  }
+
+  @Delete(':id')
+  remove(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Req() req: Request & { user: { id: string } },
+  ) {
+    return this.tasksService.remove(id, req.user.id);
+  }
+}

--- a/backend/src/tasks/tasks.module.ts
+++ b/backend/src/tasks/tasks.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TasksService } from './tasks.service';
+import { TasksController } from './tasks.controller';
+import { Task } from './entities/task.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Task])],
+  providers: [TasksService],
+  controllers: [TasksController],
+})
+export class TasksModule {}

--- a/backend/src/tasks/tasks.service.spec.ts
+++ b/backend/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TasksService } from './tasks.service';
+import { Task } from './entities/task.entity';
+
+describe('TasksService', () => {
+  let service: TasksService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        {
+          provide: getRepositoryToken(Task),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TasksService>(TasksService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Task } from './entities/task.entity';
+import { User } from '../users/entities/user.entity';
+import { CreateTaskDto } from './dto/create-task.dto';
+import { UpdateTaskDto } from './dto/update-task.dto';
+
+@Injectable()
+export class TasksService {
+  constructor(
+    @InjectRepository(Task)
+    private readonly tasksRepository: Repository<Task>,
+  ) {}
+
+  create(userId: string, createTaskDto: CreateTaskDto) {
+    const task = this.tasksRepository.create({
+      ...createTaskDto,
+      user: { id: userId } as User,
+    });
+    return this.tasksRepository.save(task);
+  }
+
+  findAllForUser(userId: string) {
+    return this.tasksRepository.find({
+      where: { user: { id: userId } },
+    });
+  }
+
+  findOneForUser(id: string, userId: string) {
+    return this.tasksRepository.findOne({
+      where: { id, user: { id: userId } },
+    });
+  }
+
+  async update(id: string, userId: string, updateTaskDto: UpdateTaskDto) {
+    const task = await this.findOneForUser(id, userId);
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+    Object.assign(task, updateTaskDto);
+    return this.tasksRepository.save(task);
+  }
+
+  async remove(id: string, userId: string) {
+    const task = await this.findOneForUser(id, userId);
+    if (!task) {
+      throw new NotFoundException('Task not found');
+    }
+    await this.tasksRepository.remove(task);
+    return task;
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -1,5 +1,12 @@
-import { BeforeInsert, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  BeforeInsert,
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  OneToMany,
+} from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import { Task } from '../../tasks/entities/task.entity';
 
 @Entity()
 export class User {
@@ -26,6 +33,9 @@ export class User {
 
   @Column({ nullable: true })
   currentHashedRefreshToken?: string;
+
+  @OneToMany(() => Task, (task) => task.user)
+  tasks: Task[];
 
   @BeforeInsert()
   async hashPassword() {


### PR DESCRIPTION
## Summary
- scaffold tasks module with controller and service
- add Task entity with enum status and link to User
- relate Users to Tasks via one-to-many
- implement JWT-protected task CRUD endpoints and ownership checks

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment errors in auth/strategies/google.strategy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68977e311bec832ca962e21c74322ea3