### PR TITLE
feat: add authentication context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,19 @@
-function App() {
+import { Routes, Route } from 'react-router-dom';
+import PrivateRoute from './PrivateRoute';
+import Home from './pages/Home';
+import Profile from './pages/Profile';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import GoogleCallback from './pages/GoogleCallback';
+
+export default function App() {
   return (
-    <div>
-      <h1 className="text-blue-700 text-5xl">Start Application</h1>
-    </div>
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+      <Route path="/auth/google/callback" element={<GoogleCallback />} />
+      <Route path="/" element={<PrivateRoute><Home /></PrivateRoute>} />
+      <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
+    </Routes>
   );
 }
-export default App;

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { api } from './services/api';
+
+interface User {
+  id?: string;
+  email?: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  accessToken: string | null;
+  isAuthenticated: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  const login = async (email: string, password: string) => {
+    const data = await api.post('/auth/login', { email, password });
+    setAccessToken(data.accessToken);
+    setUser(data.user ?? { email });
+  };
+
+  const register = async (name: string, email: string, password: string) => {
+    const data = await api.post('/auth/register', { name, email, password });
+    setAccessToken(data.accessToken);
+    setUser(data.user ?? { email });
+  };
+
+  const logout = () => {
+    setUser(null);
+    setAccessToken(null);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{ user, accessToken, isAuthenticated: !!accessToken, login, register, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/PrivateRoute.tsx
+++ b/frontend/src/PrivateRoute.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+export default function PrivateRoute({ children }: { children: ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,16 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
+import { AuthProvider } from './AuthContext';
+import { BrowserRouter } from 'react-router-dom';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
   </StrictMode>,
-)
+);

--- a/frontend/src/pages/GoogleCallback.tsx
+++ b/frontend/src/pages/GoogleCallback.tsx
@@ -1,0 +1,3 @@
+export default function GoogleCallback() {
+  return <div>Google Callback</div>;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home</div>;
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>Login</div>;
+}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,3 @@
+export default function Profile() {
+  return <div>Profile</div>;
+}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,3 @@
+export default function Register() {
+  return <div>Register</div>;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,32 @@
+const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+
+interface RequestOptions extends RequestInit {
+  json?: unknown;
+}
+
+async function request(path: string, options: RequestOptions = {}) {
+  const { json, headers, ...rest } = options;
+  const res = await fetch(`${API_URL}${path}`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers || {}),
+    },
+    ...rest,
+    body: json !== undefined ? JSON.stringify(json) : rest.body,
+  });
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.message || 'API request failed');
+  }
+
+  return res.json();
+}
+
+export const api = {
+  get: (path: string) => request(path),
+  post: (path: string, json: unknown) => request(path, { method: 'POST', json }),
+  put: (path: string, json: unknown) => request(path, { method: 'PUT', json }),
+  delete: (path: string) => request(path, { method: 'DELETE' }),
+};


### PR DESCRIPTION
## Summary
- add API helper for frontend requests
- implement AuthContext with login, register and logout helpers
- wrap app with AuthProvider
- guard authenticated pages with PrivateRoute and configure public vs protected routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897824b93c0832c85d105cd2ab01893