### PR TITLE
feat: add dashboard and profile pages

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,14 +1,21 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   // Enable CORS
   app.enableCors({
     origin: true,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
+  });
+
+  // Serve uploaded files
+  app.useStaticAssets(join(__dirname, '..', 'uploads'), {
+    prefix: '/uploads',
   });
 
   // Set global prefix

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+export class UpdateUserDto {
+  firstName?: string;
+  lastName?: string;
+}

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -1,5 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+jest.mock(
+  '@nestjs/passport',
+  () => ({
+    AuthGuard: () => class {},
+  }),
+  { virtual: true },
+);
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -7,6 +16,15 @@ describe('UsersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: {
+            findById: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<UsersController>(UsersController);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,53 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Req,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { Request, Express } from 'express';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UsersService } from './users.service';
+import { UpdateUserDto } from './dto/update-user.dto';
 
+@UseGuards(JwtAuthGuard)
 @Controller('users')
-export class UsersController {}
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  async getMe(@Req() req: Request & { user: { id: string } }) {
+    const user = await this.usersService.findById(req.user.id);
+    if (!user) return null;
+    const { password, currentHashedRefreshToken, ...rest } = user as any;
+    return rest;
+  }
+
+  @Patch('me')
+  async updateMe(
+    @Req() req: Request & { user: { id: string } },
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    await this.usersService.update(req.user.id, updateUserDto);
+    const user = await this.usersService.findById(req.user.id);
+    if (!user) return null;
+    const { password, currentHashedRefreshToken, ...rest } = user as any;
+    return rest;
+  }
+
+  @Post('me/profile-picture')
+  @UseInterceptors(FileInterceptor('file', { dest: './uploads' }))
+  async uploadProfilePicture(
+    @Req() req: Request & { user: { id: string } },
+    @UploadedFile() file: any,
+  ) {
+    const profilePictureUrl = `/uploads/${file.filename}`;
+    await this.usersService.update(req.user.id, { profilePictureUrl });
+    return { profilePictureUrl };
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import PrivateRoute from './PrivateRoute';
-import Home from './pages/Home';
-import Profile from './pages/Profile';
+import DashboardPage from './pages/DashboardPage';
+import ProfilePage from './pages/ProfilePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import GoogleCallbackPage from './pages/GoogleCallbackPage';
@@ -12,8 +12,8 @@ export default function App() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/auth/google/callback" element={<GoogleCallbackPage />} />
-      <Route path="/" element={<PrivateRoute><Home /></PrivateRoute>} />
-      <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
+      <Route path="/" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
+      <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
     </Routes>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+interface Task {
+  id: string;
+  title: string;
+  description?: string;
+  status: 'TODO' | 'IN_PROGRESS' | 'DONE';
+}
+
+export default function DashboardPage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const fetchTasks = async () => {
+    const res = await api.get<Task[]>('/tasks');
+    setTasks(res.data);
+  };
+
+  useEffect(() => {
+    void fetchTasks();
+  }, []);
+
+  const addTask = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await api.post('/tasks', { title, description });
+    setTitle('');
+    setDescription('');
+    void fetchTasks();
+  };
+
+  const deleteTask = async (id: string) => {
+    await api.delete(`/tasks/${id}`);
+    void fetchTasks();
+  };
+
+  const updateStatus = async (id: string, status: Task['status']) => {
+    await api.patch(`/tasks/${id}`, { status });
+    void fetchTasks();
+  };
+
+  const editTask = async (task: Task) => {
+    const newTitle = prompt('Title', task.title);
+    if (newTitle === null) return;
+    const newDescription = prompt('Description', task.description ?? '') ?? '';
+    await api.patch(`/tasks/${task.id}`, {
+      title: newTitle,
+      description: newDescription,
+    });
+    void fetchTasks();
+  };
+
+  return (
+    <div>
+      <h2>Tasks</h2>
+      <form onSubmit={addTask}>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+        />
+        <input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Description"
+        />
+        <button type="submit">Add Task</button>
+      </form>
+      <ul>
+        {tasks.map((task) => (
+          <li key={task.id}>
+            <strong>{task.title}</strong> - {task.description}
+            <select
+              value={task.status}
+              onChange={(e) =>
+                updateStatus(task.id, e.target.value as Task['status'])
+              }
+            >
+              <option value="TODO">Todo</option>
+              <option value="IN_PROGRESS">In Progress</option>
+              <option value="DONE">Done</option>
+            </select>
+            <button type="button" onClick={() => editTask(task)}>
+              Edit
+            </button>
+            <button type="button" onClick={() => deleteTask(task.id)}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,3 +1,0 @@
-export default function Home() {
-  return <div>Home</div>;
-}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,3 +1,0 @@
-export default function Profile() {
-  return <div>Profile</div>;
-}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import api from '../api';
+import { useAuth } from '../useAuth';
+
+export default function ProfilePage() {
+  const { user, refreshUser } = useAuth();
+  const [firstName, setFirstName] = useState(user?.firstName ?? '');
+  const [lastName, setLastName] = useState(user?.lastName ?? '');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await api.patch('/users/me', { firstName, lastName });
+    await refreshUser();
+  };
+
+  const handleFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    await api.post('/users/me/profile-picture', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    await refreshUser();
+  };
+
+  return (
+    <div>
+      <h2>Profile</h2>
+      {user?.profilePictureUrl && (
+        <img
+          src={new URL(user.profilePictureUrl, import.meta.env.VITE_API_URL).href}
+          alt="Profile"
+          width={100}
+        />
+      )}
+      <p>Email: {user?.email}</p>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          placeholder="First Name"
+        />
+        <input
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          placeholder="Last Name"
+        />
+        <button type="submit">Save</button>
+      </form>
+      <input type="file" onChange={handleFileChange} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement user update and profile image upload endpoints
- add task dashboard and profile pages with auth context updates

## Testing
- `cd backend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68978a27a3b8832c8b84cf6927a58acb