### PR TITLE
Fix frontend registration name fields

### DIFF
--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -77,8 +77,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const register = async (name: string, email: string, password: string) => {
+    const [firstName, ...rest] = name.trim().split(" ");
+    const lastName = rest.join(" ") || "";
     const res = await api.post<AuthResponse>("/auth/register", {
-      name,
+      firstName,
+      lastName,
       email,
       password,
     });


### PR DESCRIPTION
## Summary
- parse user-provided name into first and last name
- send both names to backend during registration

## Testing
- `npm test --prefix backend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689845e0c5ac832cac35f15ee27e90ce