### PR TITLE
feat: add email verification flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ JWT_REFRESH_TOKEN_EXPIRATION_TIME=7d # 7 days
 
 # CORS Environment Variables
 FRONTEND_URL=http://localhost:5173
+BACKEND_URL=http://localhost:3000/api/v1
 
 # Frontend Environment Variables
 VITE_API_URL=http://localhost:3000/api/v1
@@ -24,3 +25,8 @@ VITE_API_URL=http://localhost:3000/api/v1
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL=http://localhost:3000/api/v1/auth/google/callback
+
+# Mail Configuration for Mailpit
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_FROM=no-reply@example.com

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   Req,
   Res,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
@@ -26,6 +27,24 @@ export class AuthController {
   @Post('register')
   async register(@Body() createUserDto: CreateUserDto) {
     return this.authService.register(createUserDto);
+  }
+
+  @Get('verify-email')
+  async verifyEmail(
+    @Query('token') token: string,
+    @Query('email') email: string,
+    @Res() res: Response,
+  ) {
+    await this.authService.verifyEmail(email, token);
+    return res.redirect(
+      `${this.configService.get<string>('FRONTEND_URL')}/verify/success`,
+    );
+  }
+
+  @Post('resend-verification')
+  async resendVerification(@Body('email') email: string) {
+    await this.authService.resendVerification(email);
+    return { message: 'Verification email sent' };
   }
 
   @UseGuards(LocalAuthGuard)

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -9,11 +10,14 @@ import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
 import { GoogleStrategy } from './strategies/google.strategy';
 import { AuthController } from './auth.controller';
+import { EmailVerification } from './entities/email-verification.entity';
+import { MailService } from './mail.service';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
+    TypeOrmModule.forFeature([EmailVerification]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -33,6 +37,7 @@ import { AuthController } from './auth.controller';
     JwtStrategy,
     JwtRefreshStrategy,
     GoogleStrategy,
+    MailService,
   ],
   exports: [AuthService],
 })

--- a/backend/src/auth/entities/email-verification.entity.ts
+++ b/backend/src/auth/entities/email-verification.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity()
+export class EmailVerification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  token: string;
+
+  @Column()
+  expiresAt: Date;
+
+  @Column({ default: false })
+  used: boolean;
+
+  @ManyToOne(() => User, (user) => user.emailVerifications, {
+    onDelete: 'CASCADE',
+  })
+  user: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+

--- a/backend/src/auth/mail.service.ts
+++ b/backend/src/auth/mail.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Socket } from 'net';
+
+@Injectable()
+export class MailService {
+  constructor(private readonly configService: ConfigService) {}
+
+  async sendVerificationEmail(email: string, token: string) {
+    const host = this.configService.get<string>('MAIL_HOST') || 'mailpit';
+    const port = parseInt(
+      this.configService.get<string>('MAIL_PORT') || '1025',
+      10,
+    );
+    const from =
+      this.configService.get<string>('MAIL_FROM') || 'no-reply@example.com';
+    const backendUrl =
+      this.configService.get<string>('BACKEND_URL') ||
+      'http://localhost:3000/api/v1';
+    const verifyUrl = `${backendUrl}/auth/verify-email?token=${token}&email=${encodeURIComponent(
+      email,
+    )}`;
+
+    const socket = new Socket();
+
+    await new Promise<void>((resolve) => {
+      socket.connect(port, host, () => resolve());
+    });
+
+    const commands = [
+      `HELO localhost`,
+      `MAIL FROM:<${from}>`,
+      `RCPT TO:<${email}>`,
+      `DATA`,
+      `Subject: Verify your email`,
+      ``,
+      `Click the link to verify your email: ${verifyUrl}`,
+      `.`,
+      `QUIT`,
+    ];
+
+    for (const cmd of commands) {
+      socket.write(cmd + '\r\n');
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    socket.end();
+  }
+}
+

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { Task } from '../../tasks/entities/task.entity';
+import { EmailVerification } from '../../auth/entities/email-verification.entity';
 
 @Entity()
 export class User {
@@ -36,6 +37,12 @@ export class User {
 
   @OneToMany(() => Task, (task) => task.user)
   tasks: Task[];
+
+  @Column({ default: false })
+  isEmailVerified: boolean;
+
+  @OneToMany(() => EmailVerification, (verification) => verification.user)
+  emailVerifications: EmailVerification[];
 
   @BeforeInsert()
   async hashPassword() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,15 @@ services:
     networks:
       - service-network
 
+  mailpit:
+    image: axllent/mailpit
+    container_name: mailpit
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - service-network
+
 volumes:
   postgres_data:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ProfilePage from './pages/ProfilePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import GoogleCallbackPage from './pages/GoogleCallbackPage';
+import VerifySuccessPage from './pages/VerifySuccessPage';
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/auth/google/callback" element={<GoogleCallbackPage />} />
+      <Route path="/verify/success" element={<VerifySuccessPage />} />
       <Route path="/" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
       <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
     </Routes>

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -26,6 +26,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (name: string, email: string, password: string) => Promise<void>;
+  resendVerification: (email: string) => Promise<void>;
   logout: () => void;
   setAuth: (data: AuthResponse) => void;
   refreshUser: () => Promise<void>;
@@ -79,14 +80,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const register = async (name: string, email: string, password: string) => {
     const [firstName, ...rest] = name.trim().split(" ");
     const lastName = rest.join(" ") || "";
-    const res = await api.post<AuthResponse>("/auth/register", {
+    await api.post("/auth/register", {
       firstName,
       lastName,
       email,
       password,
     });
-    setAuth(res.data);
-    await refreshUser();
+  };
+
+  const resendVerification = async (email: string) => {
+    await api.post("/auth/resend-verification", { email });
   };
 
   const logout = useCallback(() => {
@@ -124,6 +127,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isAuthenticated: !!accessToken,
         login,
         register,
+        resendVerification,
         logout,
         setAuth,
         refreshUser,

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,17 +1,39 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "../useAuth";
+import type { AxiosError } from "axios";
 
 export default function LoginPage() {
-  const { login } = useAuth();
+  const { login, resendVerification } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [info, setInfo] = useState("");
+  const [showResend, setShowResend] = useState(false);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
+    setInfo("");
     try {
       await login(email, password);
+      setShowResend(false);
+    } catch (err) {
+      const axiosErr = err as AxiosError;
+      if (axiosErr.response?.status === 403) {
+        setError("Please verify your email");
+        setShowResend(true);
+      } else {
+        setError((err as Error).message);
+      }
+    }
+  };
+
+  const handleResend = async () => {
+    setError("");
+    setInfo("");
+    try {
+      await resendVerification(email);
+      setInfo("Verification email sent");
     } catch (err) {
       setError((err as Error).message);
     }
@@ -26,6 +48,11 @@ export default function LoginPage() {
         {error && (
           <p className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4 text-sm">
             {error}
+          </p>
+        )}
+        {info && (
+          <p className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4 text-sm">
+            {info}
           </p>
         )}
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -69,6 +96,15 @@ export default function LoginPage() {
           >
             Login
           </button>
+          {showResend && (
+            <button
+              type="button"
+              onClick={handleResend}
+              className="w-full mt-2 flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-purple-600 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
+            >
+              Resend verification
+            </button>
+          )}
         </form>
         <div className="mt-6 text-center">
           <a

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -8,12 +8,14 @@ export default function RegisterPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
     try {
       await register(name, email, password);
+      setMessage("กรุณายืนยันอีเมลในกล่องเข้า");
     } catch (err) {
       setError((err as Error).message);
     }
@@ -28,6 +30,11 @@ export default function RegisterPage() {
         {error && (
           <p className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4 text-sm">
             {error}
+          </p>
+        )}
+        {message && (
+          <p className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4 text-sm">
+            {message}
           </p>
         )}
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/pages/VerifySuccessPage.tsx
+++ b/frontend/src/pages/VerifySuccessPage.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+
+export default function VerifySuccessPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-md text-center">
+        <h1 className="text-2xl font-bold mb-4">ยืนยันอีเมลเรียบร้อยแล้ว</h1>
+        <Link
+          to="/login"
+          className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          ไปล็อกอิน
+        </Link>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add email verification tokens and SMTP mail service
- gate login on verified email and expose verification/resend endpoints
- integrate frontend pages for registration, resend prompt, and success redirect

## Testing
- `npm run lint` (frontend)
- `npm run lint` (backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b9fd2818832c9852fab7ce225d47