### PR TITLE
feat(frontend): add responsive layout and auth navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,16 +6,25 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import GoogleCallbackPage from './pages/GoogleCallbackPage';
 import VerifySuccessPage from './pages/VerifySuccessPage';
+import Layout from './components/Layout';
 
 export default function App() {
   return (
     <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
-      <Route path="/auth/google/callback" element={<GoogleCallbackPage />} />
-      <Route path="/verify/success" element={<VerifySuccessPage />} />
-      <Route path="/" element={<PrivateRoute><DashboardPage /></PrivateRoute>} />
-      <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
+      <Route element={<Layout />}>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/auth/google/callback" element={<GoogleCallbackPage />} />
+        <Route path="/verify/success" element={<VerifySuccessPage />} />
+        <Route
+          path="/"
+          element={<PrivateRoute><DashboardPage /></PrivateRoute>}
+        />
+        <Route
+          path="/profile"
+          element={<PrivateRoute><ProfilePage /></PrivateRoute>}
+        />
+      </Route>
     </Routes>
   );
 }

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,8 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-100 py-4 text-center text-sm text-gray-500">
+      © {new Date().getFullYear()} Example Auth
+    </footer>
+  );
+}
+

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from "react-router-dom";
+import Navbar from "./Navbar";
+import Footer from "./Footer";
+
+export default function Layout() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1">
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../useAuth";
+
+export default function Navbar() {
+  const { isAuthenticated, logout } = useAuth();
+  const navigate = useNavigate();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login");
+  };
+
+  const toggleMenu = () => setMenuOpen(!menuOpen);
+
+  return (
+    <nav className="bg-gray-800 text-white">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <div className="flex items-center">
+            <Link to="/" className="text-xl font-bold">
+              Example Auth
+            </Link>
+          </div>
+          <div className="hidden md:flex md:items-center md:space-x-4">
+            {isAuthenticated ? (
+              <>
+                <Link
+                  to="/"
+                  className="rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-700"
+                >
+                  Dashboard
+                </Link>
+                <Link
+                  to="/profile"
+                  className="rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-700"
+                >
+                  Profile
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  className="rounded-md bg-red-500 px-3 py-2 text-sm font-medium hover:bg-red-600"
+                >
+                  Logout
+                </button>
+              </>
+            ) : (
+              <>
+                <Link
+                  to="/login"
+                  className="rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-700"
+                >
+                  Login
+                </Link>
+                <Link
+                  to="/register"
+                  className="rounded-md bg-blue-500 px-3 py-2 text-sm font-medium hover:bg-blue-600"
+                >
+                  Register
+                </Link>
+              </>
+            )}
+          </div>
+          <div className="md:hidden">
+            <button
+              onClick={toggleMenu}
+              className="inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-700 focus:outline-none"
+            >
+              <svg
+                className="block h-6 w-6"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                {menuOpen ? (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                ) : (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                )}
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      {menuOpen && (
+        <div className="space-y-1 px-2 pb-3 pt-2 md:hidden">
+          {isAuthenticated ? (
+            <>
+              <Link
+                to="/"
+                className="block rounded-md px-3 py-2 text-base font-medium hover:bg-gray-700"
+                onClick={() => setMenuOpen(false)}
+              >
+                Dashboard
+              </Link>
+              <Link
+                to="/profile"
+                className="block rounded-md px-3 py-2 text-base font-medium hover:bg-gray-700"
+                onClick={() => setMenuOpen(false)}
+              >
+                Profile
+              </Link>
+              <button
+                onClick={() => {
+                  handleLogout();
+                  setMenuOpen(false);
+                }}
+                className="block w-full rounded-md bg-red-500 px-3 py-2 text-left text-base font-medium hover:bg-red-600"
+              >
+                Logout
+              </button>
+            </>
+          ) : (
+            <>
+              <Link
+                to="/login"
+                className="block rounded-md px-3 py-2 text-base font-medium hover:bg-gray-700"
+                onClick={() => setMenuOpen(false)}
+              >
+                Login
+              </Link>
+              <Link
+                to="/register"
+                className="block rounded-md bg-blue-500 px-3 py-2 text-base font-medium hover:bg-blue-600"
+                onClick={() => setMenuOpen(false)}
+              >
+                Register
+              </Link>
+            </>
+          )}
+        </div>
+      )}
+    </nav>
+  );
+}
+

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,9 +1,11 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "../useAuth";
 import type { AxiosError } from "axios";
+import { useNavigate } from "react-router-dom";
 
 export default function LoginPage() {
   const { login, resendVerification } = useAuth();
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -17,6 +19,7 @@ export default function LoginPage() {
     try {
       await login(email, password);
       setShowResend(false);
+      navigate("/");
     } catch (err) {
       const axiosErr = err as AxiosError;
       if (axiosErr.response?.status === 403) {

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,9 +1,11 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "../useAuth";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import type { AxiosError } from "axios";
 
 export default function RegisterPage() {
-  const { register } = useAuth();
+  const { register, login } = useAuth();
+  const navigate = useNavigate();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -13,9 +15,20 @@ export default function RegisterPage() {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
+    setMessage("");
     try {
       await register(name, email, password);
-      setMessage("กรุณายืนยันอีเมลในกล่องเข้า");
+      try {
+        await login(email, password);
+        navigate("/");
+      } catch (err) {
+        const axiosErr = err as AxiosError;
+        if (axiosErr.response?.status === 403) {
+          setMessage("กรุณายืนยันอีเมลในกล่องเข้า");
+        } else {
+          setError((err as Error).message);
+        }
+      }
     } catch (err) {
       setError((err as Error).message);
     }


### PR DESCRIPTION
## Summary
- add global layout with navbar and footer
- show login/register or dashboard/profile/logout based on auth state
- redirect users to dashboard after login or successful registration

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898da662eb0832cab52e3fdcb21d6f4