### PR TITLE
feat: verify Google login emails

### DIFF
--- a/backend/src/auth/strategies/google.strategy.ts
+++ b/backend/src/auth/strategies/google.strategy.ts
@@ -37,8 +37,14 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
         lastName: profile.name?.familyName,
         profilePictureUrl: profile.photos?.[0]?.value,
         googleId: profile.id,
+        // Users authenticated via Google are implicitly verified
+        isEmailVerified: true,
       };
       user = await this.usersService.create(newUser);
+    } else if (!user.isEmailVerified) {
+      // Existing users logging in with Google should be marked verified
+      await this.usersService.update(user.id, { isEmailVerified: true });
+      user.isEmailVerified = true;
     }
     return user;
   }

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -5,4 +5,5 @@ export class CreateUserDto {
   lastName?: string;
   profilePictureUrl?: string;
   googleId?: string;
+  isEmailVerified?: boolean;
 }


### PR DESCRIPTION
## Summary
- mark emails as verified when users authenticate with Google
- allow CreateUserDto to accept isEmailVerified flag

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment errors)*

------
https://chatgpt.com/codex/tasks/task_e_689982835f04832cb8dc9a16301ac18b