### PR TITLE
feat: add email verification flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import GoogleCallbackPage from './pages/GoogleCallbackPage';
 import VerifySuccessPage from './pages/VerifySuccessPage';
+import VerifyEmailPage from './pages/VerifyEmailPage';
 import Layout from './components/Layout';
 
 export default function App() {
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/auth/google/callback" element={<GoogleCallbackPage />} />
+        <Route path="/verify/email" element={<VerifyEmailPage />} />
         <Route path="/verify/success" element={<VerifySuccessPage />} />
         <Route
           path="/"

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,34 +1,21 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "../useAuth";
 import { Link, useNavigate } from "react-router-dom";
-import type { AxiosError } from "axios";
 
 export default function RegisterPage() {
-  const { register, login } = useAuth();
+  const { register } = useAuth();
   const navigate = useNavigate();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const [message, setMessage] = useState("");
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError("");
-    setMessage("");
     try {
       await register(name, email, password);
-      try {
-        await login(email, password);
-        navigate("/");
-      } catch (err) {
-        const axiosErr = err as AxiosError;
-        if (axiosErr.response?.status === 403) {
-          setMessage("กรุณายืนยันอีเมลในกล่องเข้า");
-        } else {
-          setError((err as Error).message);
-        }
-      }
+      navigate(`/verify/email?email=${encodeURIComponent(email)}`);
     } catch (err) {
       setError((err as Error).message);
     }
@@ -43,11 +30,6 @@ export default function RegisterPage() {
         {error && (
           <p className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4 text-sm">
             {error}
-          </p>
-        )}
-        {message && (
-          <p className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4 text-sm">
-            {message}
           </p>
         )}
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -1,0 +1,23 @@
+import { Link, useSearchParams } from "react-router-dom";
+
+export default function VerifyEmailPage() {
+  const [params] = useSearchParams();
+  const email = params.get("email");
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-md text-center">
+        <h1 className="text-2xl font-bold mb-4">กรุณายืนยันอีเมลของคุณ</h1>
+        {email && (
+          <p className="mb-4">เราได้ส่งลิงก์ยืนยันไปที่ {email}</p>
+        )}
+        <p className="mb-4">โปรดตรวจสอบกล่องจดหมายของคุณและคลิกลิงก์ยืนยัน</p>
+        <Link
+          to="/login"
+          className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          ไปล็อกอิน
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add VerifyEmail page to instruct users to confirm their email
- redirect registrations to email verification page
- wire verify routes into router

## Testing
- `npm test` (frontend, fails: Missing script "test")
- `npm run lint` (frontend)
- `npm test` (backend)
- `npm run lint` (backend, fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_6899d6c4fcc0832c9ed17821195cdb6f