### PR TITLE
fix frontend build issues and stabilize user service tests

### DIFF
--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -38,6 +38,8 @@ describe('UsersService', () => {
 
     service = module.get<UsersService>(UsersService);
     jest.clearAllMocks();
+    compareMock.mockResolvedValue(true);
+    hashMock.mockResolvedValue('hashed');
   });
 
   it('should be defined', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
 import DashboardPage from './pages/DashboardPage';
 import ProfilePage from './pages/ProfilePage';

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState, FormEvent, ChangeEvent } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import type { FormEvent, ChangeEvent } from 'react';
 import {
   getTasks,
   createTask,
   updateTask,
   deleteTask,
-  Task,
 } from '../api/tasks';
+import type { Task } from '../api/tasks';
 
 const statusFlow: Task['status'][] = ['TODO', 'IN_PROGRESS', 'DONE'];
 
@@ -40,7 +41,7 @@ export default function TasksPage() {
     validateField(name, value);
   };
 
-  const load = async () => {
+  const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -55,11 +56,11 @@ export default function TasksPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [statusFilter, sortOrder]);
 
   useEffect(() => {
-    load();
-  }, [statusFilter, sortOrder]);
+    void load();
+  }, [load]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- remove unused Navigate import
- use type-only React imports and stabilize task loader with useCallback
- reset bcrypt mocks in user service tests to ensure consistent behavior

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run build` (frontend)
- `npm run lint` (frontend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689a1966a58c832c9e5fec38cf19ca14