### PR TITLE
fix: enable local login and token refresh

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -17,11 +17,19 @@ export class UsersService {
   }
 
   async findByEmail(email: string): Promise<User | null> {
-    return this.usersRepository.findOne({ where: { email } });
+    return this.usersRepository
+      .createQueryBuilder('user')
+      .addSelect('user.password')
+      .where('user.email = :email', { email })
+      .getOne();
   }
 
   async findById(id: string): Promise<User | null> {
-    return this.usersRepository.findOne({ where: { id } });
+    return this.usersRepository
+      .createQueryBuilder('user')
+      .addSelect('user.currentHashedRefreshToken')
+      .where('user.id = :id', { id })
+      .getOne();
   }
 
   async findByGoogleId(googleId: string): Promise<User | null> {


### PR DESCRIPTION
## Summary
- include password when looking up users by email
- select refresh token when retrieving users by id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a225d9258832c9ae365ab16d1c92f