### PR TITLE
Fix social login callback navigation

### DIFF
--- a/frontend/src/pages/FacebookCallbackPage.tsx
+++ b/frontend/src/pages/FacebookCallbackPage.tsx
@@ -10,7 +10,14 @@ export default function FacebookCallbackPage() {
     const params = new URLSearchParams(window.location.search);
     const accessToken = params.get("accessToken");
     const userParam = params.get("user");
-    const user = userParam ? JSON.parse(userParam) : undefined;
+    let user;
+    if (userParam) {
+      try {
+        user = JSON.parse(decodeURIComponent(userParam));
+      } catch (error) {
+        console.error("Failed to parse user info", error);
+      }
+    }
     if (accessToken) {
       setAuth({ accessToken, user });
       void refreshUser();

--- a/frontend/src/pages/GoogleCallbackPage.tsx
+++ b/frontend/src/pages/GoogleCallbackPage.tsx
@@ -10,7 +10,14 @@ export default function GoogleCallbackPage() {
     const params = new URLSearchParams(window.location.search);
     const accessToken = params.get("accessToken");
     const userParam = params.get("user");
-    const user = userParam ? JSON.parse(userParam) : undefined;
+    let user;
+    if (userParam) {
+      try {
+        user = JSON.parse(decodeURIComponent(userParam));
+      } catch (error) {
+        console.error("Failed to parse user info", error);
+      }
+    }
     if (accessToken) {
       setAuth({ accessToken, user });
       void refreshUser();


### PR DESCRIPTION
## Summary
- decode and parse user info in Google and Facebook OAuth callback pages
- add error handling so dashboard navigation runs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689adc52a1b0832c976e4b9092193b36